### PR TITLE
Math magians: Feature add unit test using jest and react testing library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 .babelrc
+
+__snapshots__/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.2",
-        "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
         "big.js": "^6.1.1",
         "prop-types": "^15.8.1",
@@ -24,6 +23,7 @@
         "@babel/eslint-parser": "^7.17.0",
         "@babel/plugin-syntax-jsx": "^7.16.7",
         "@babel/preset-react": "^7.16.7",
+        "@testing-library/react": "^12.1.2",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^18.2.1",
         "eslint-plugin-import": "^2.25.4",
@@ -3251,6 +3251,7 @@
       "version": "12.1.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.2.tgz",
       "integrity": "sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.0.0"
@@ -19526,6 +19527,7 @@
       "version": "12.1.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.2.tgz",
       "integrity": "sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jsx-a11y": "^6.5.1",
         "eslint-plugin-react": "^7.28.0",
+        "react-test-renderer": "^17.0.2",
         "stylelint": "^14.3.0",
         "stylelint-config-standard": "^24.0.0",
         "stylelint-csstree-validator": "^2.0.0",
@@ -13950,6 +13951,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/react-shallow-renderer": {
+      "version": "16.14.1",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
+      "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
+      "dev": true,
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+      "dev": true,
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^17.0.2",
+        "react-shallow-renderer": "^16.13.1",
+        "scheduler": "^0.20.2"
+      },
+      "peerDependencies": {
+        "react": "17.0.2"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -27212,6 +27241,28 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
+      }
+    },
+    "react-shallow-renderer": {
+      "version": "16.14.1",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
+      "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0"
+      }
+    },
+    "react-test-renderer": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^17.0.2",
+        "react-shallow-renderer": "^16.13.1",
+        "scheduler": "^0.20.2"
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.2",
-    "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
     "big.js": "^6.1.1",
     "prop-types": "^15.8.1",
@@ -43,6 +42,7 @@
     "@babel/eslint-parser": "^7.17.0",
     "@babel/plugin-syntax-jsx": "^7.16.7",
     "@babel/preset-react": "^7.16.7",
+    "@testing-library/react": "^12.1.2",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-plugin-import": "^2.25.4",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-react": "^7.28.0",
+    "react-test-renderer": "^17.0.2",
     "stylelint": "^14.3.0",
     "stylelint-config-standard": "^24.0.0",
     "stylelint-csstree-validator": "^2.0.0",

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,0 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/__tests__/Button.test.js
+++ b/src/__tests__/Button.test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Button from '../components/Button';
+
+it('Button component renders correctly', () => {
+  const handleButtonClick = (name) => name;
+  const tree = renderer
+    .create(<Button clickHandler={handleButtonClick} name="AC" />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/__tests__/Calculator.test.js
+++ b/src/__tests__/Calculator.test.js
@@ -1,4 +1,7 @@
 import renderer from 'react-test-renderer';
+import {render, fireEvent, waitFor, screen} from '@testing-library/react'
+import '@testing-library/jest-dom'
+
 import Calculator from "../components/Calculator";
 
 it('Calculator component renders correctly', () => {
@@ -7,3 +10,12 @@ it('Calculator component renders correctly', () => {
     .toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+
+test('Calculator button click displays button\'s value in the display', async () => {
+  render(<Calculator />)
+
+  fireEvent.click(screen.getByText('9'))
+
+  expect(screen.getByRole('display')).toHaveTextContent('9')
+})

--- a/src/__tests__/Calculator.test.js
+++ b/src/__tests__/Calculator.test.js
@@ -1,0 +1,9 @@
+import renderer from 'react-test-renderer';
+import Calculator from "../components/Calculator";
+
+it('Calculator component renders correctly', () => {
+  const tree = renderer
+    .create(<Calculator />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/__tests__/Calculator.test.js
+++ b/src/__tests__/Calculator.test.js
@@ -1,8 +1,8 @@
 import renderer from 'react-test-renderer';
-import {render, fireEvent, waitFor, screen} from '@testing-library/react'
-import '@testing-library/jest-dom'
+import { render, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 
-import Calculator from "../components/Calculator";
+import Calculator from '../components/Calculator';
 
 it('Calculator component renders correctly', () => {
   const tree = renderer
@@ -11,11 +11,10 @@ it('Calculator component renders correctly', () => {
   expect(tree).toMatchSnapshot();
 });
 
-
 test('Calculator button click displays button\'s value in the display', async () => {
-  render(<Calculator />)
+  render(<Calculator />);
 
-  fireEvent.click(screen.getByText('9'))
+  fireEvent.click(screen.getByText('9'));
 
-  expect(screen.getByRole('display')).toHaveTextContent('9')
-})
+  expect(screen.getByTestId('display')).toHaveTextContent('9');
+});

--- a/src/__tests__/Display.test.js
+++ b/src/__tests__/Display.test.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Display from '../components/Display';
+
+it('Display component renders correctly', () => {
+  const tree = renderer
+    .create(<Display text="9" />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/__tests__/calculate.test.js
+++ b/src/__tests__/calculate.test.js
@@ -1,0 +1,121 @@
+import calculate from '../logic/calculate';
+
+describe("unit test calculate function", () => {
+  const obj = {
+    total: "10",
+    next: "4",
+    operation: "+",
+  }
+
+  test('test button AC', () => { 
+    expect(calculate(obj, "AC").total).toBe(null);
+  }) 
+
+  test('test button 0 and next 0', () => { 
+    obj.total = "100";
+    obj.next = "0";
+    expect(calculate(obj, "0")).toStrictEqual({});
+  }) 
+
+  test('test button 0 and next is non-zero number', () => { 
+    obj.total = "100";
+    obj.next = "5";
+    expect(calculate(obj, "0").next).toBe("50");
+  }) 
+
+  test('test where button->number, operation->not null and next-> null', () => { 
+    obj.total = "100";
+    obj.next = null;
+    expect(calculate(obj, "6").next).toBe("6");
+  }) 
+
+  test('test where button->number, operation-> null and next-> not null', () => { 
+    obj.total = "100";
+    obj.next = "6";
+    obj.operation = null;
+    expect(calculate(obj, "5").next).toBe("65");
+    expect(calculate(obj, "5").total).toBe(null);
+  }) 
+
+  test('test where button->dotand next-> includes dot', () => { 
+    obj.total = "100";
+    obj.next = "0.6";
+    obj.operation = null;
+    expect(calculate(obj, ".").next).toBe("0.6");
+  }) 
+
+  test('test where button->dotand next-> does not include dot', () => { 
+    obj.total = "100";
+    obj.next = "6";
+    obj.operation = null;
+    expect(calculate(obj, ".").next).toBe("6.");
+  }) 
+
+  test('test where button->dot and operation not null', () => { 
+    obj.total = "100";
+    obj.next = null;
+    obj.operation = "+";
+    expect(calculate(obj, ".").next).toBe("0.");
+  }) 
+
+  test('test where button->dot, total includes dot and operation & next are null', () => { 
+    obj.total = "100.5";
+    obj.next = null;
+    obj.operation = null;
+    expect(calculate(obj, ".")).toStrictEqual({});
+  }) 
+
+  test('test where button is dot, total includes dot and operation & next are null', () => { 
+    obj.total = "100";
+    obj.next = null;
+    obj.operation = null;
+    expect(calculate(obj, ".").total).toBe("100.");
+  }) 
+
+  test('test where button is = and operation & next are not null', () => { 
+    obj.total = "100";
+    obj.next = "7";
+    obj.operation = "-";
+    expect(calculate(obj, "=").total).toBe("93");
+    expect(calculate(obj, "=").next).toBe(null);
+    expect(calculate(obj, "=").operation).toBe(null);
+  }) 
+
+  test('test where button is = and operation or next are null', () => { 
+    obj.total = "100";
+    obj.next = "7";
+    obj.operation = null;
+    expect(calculate(obj, "=")).toStrictEqual({});
+  }) 
+
+  test('test where button is +/- and next is not null', () => { 
+    obj.total = "100";
+    obj.next = "7";
+    obj.operation = null;
+    expect(calculate(obj, "+/-").next).toBe("-7");
+  }) 
+
+  test('test where button is +/- and next is null', () => { 
+    obj.total = "100";
+    obj.next = null;
+    obj.operation = null;
+    expect(calculate(obj, "+/-").total).toBe("-100");
+  }) 
+
+  test('test where button is + and next & operation are null', () => { 
+    obj.total = "100";
+    obj.next = null;
+    obj.operation = "-";
+    expect(calculate(obj, "+").operation).toBe("+");
+    expect(calculate(obj, "+").total).toBe("100");
+  }) 
+  
+  test('test where button is + and next & operation are null', () => { 
+    obj.total = "100";
+    obj.next = "8";
+    obj.operation = "-";
+    expect(calculate(obj, "+").total).toBe("92");
+    expect(calculate(obj, "+").operation).toBe("+");
+    expect(calculate(obj, "+").next).toBe(null);
+  }) 
+});

--- a/src/__tests__/calculate.test.js
+++ b/src/__tests__/calculate.test.js
@@ -1,121 +1,121 @@
 import calculate from '../logic/calculate';
 
-describe("unit test calculate function", () => {
+describe('unit test calculate function', () => {
   const obj = {
-    total: "10",
-    next: "4",
-    operation: "+",
-  }
+    total: '10',
+    next: '4',
+    operation: '+',
+  };
 
-  test('test button AC', () => { 
-    expect(calculate(obj, "AC").total).toBe(null);
-  }) 
+  test('test button AC', () => {
+    expect(calculate(obj, 'AC').total).toBe(null);
+  });
 
-  test('test button 0 and next 0', () => { 
-    obj.total = "100";
-    obj.next = "0";
-    expect(calculate(obj, "0")).toStrictEqual({});
-  }) 
+  test('test button 0 and next 0', () => {
+    obj.total = '100';
+    obj.next = '0';
+    expect(calculate(obj, '0')).toStrictEqual({});
+  });
 
-  test('test button 0 and next is non-zero number', () => { 
-    obj.total = "100";
-    obj.next = "5";
-    expect(calculate(obj, "0").next).toBe("50");
-  }) 
+  test('test button 0 and next is non-zero number', () => {
+    obj.total = '100';
+    obj.next = '5';
+    expect(calculate(obj, '0').next).toBe('50');
+  });
 
-  test('test where button->number, operation->not null and next-> null', () => { 
-    obj.total = "100";
+  test('test where button->number, operation->not null and next-> null', () => {
+    obj.total = '100';
     obj.next = null;
-    expect(calculate(obj, "6").next).toBe("6");
-  }) 
+    expect(calculate(obj, '6').next).toBe('6');
+  });
 
-  test('test where button->number, operation-> null and next-> not null', () => { 
-    obj.total = "100";
-    obj.next = "6";
+  test('test where button->number, operation-> null and next-> not null', () => {
+    obj.total = '100';
+    obj.next = '6';
     obj.operation = null;
-    expect(calculate(obj, "5").next).toBe("65");
-    expect(calculate(obj, "5").total).toBe(null);
-  }) 
+    expect(calculate(obj, '5').next).toBe('65');
+    expect(calculate(obj, '5').total).toBe(null);
+  });
 
-  test('test where button->dotand next-> includes dot', () => { 
-    obj.total = "100";
-    obj.next = "0.6";
+  test('test where button->dotand next-> includes dot', () => {
+    obj.total = '100';
+    obj.next = '0.6';
     obj.operation = null;
-    expect(calculate(obj, ".").next).toBe("0.6");
-  }) 
+    expect(calculate(obj, '.').next).toBe('0.6');
+  });
 
-  test('test where button->dotand next-> does not include dot', () => { 
-    obj.total = "100";
-    obj.next = "6";
+  test('test where button->dotand next-> does not include dot', () => {
+    obj.total = '100';
+    obj.next = '6';
     obj.operation = null;
-    expect(calculate(obj, ".").next).toBe("6.");
-  }) 
+    expect(calculate(obj, '.').next).toBe('6.');
+  });
 
-  test('test where button->dot and operation not null', () => { 
-    obj.total = "100";
+  test('test where button->dot and operation not null', () => {
+    obj.total = '100';
     obj.next = null;
-    obj.operation = "+";
-    expect(calculate(obj, ".").next).toBe("0.");
-  }) 
+    obj.operation = '+';
+    expect(calculate(obj, '.').next).toBe('0.');
+  });
 
-  test('test where button->dot, total includes dot and operation & next are null', () => { 
-    obj.total = "100.5";
-    obj.next = null;
-    obj.operation = null;
-    expect(calculate(obj, ".")).toStrictEqual({});
-  }) 
-
-  test('test where button is dot, total includes dot and operation & next are null', () => { 
-    obj.total = "100";
+  test('test where button->dot, total includes dot and operation & next are null', () => {
+    obj.total = '100.5';
     obj.next = null;
     obj.operation = null;
-    expect(calculate(obj, ".").total).toBe("100.");
-  }) 
+    expect(calculate(obj, '.')).toStrictEqual({});
+  });
 
-  test('test where button is = and operation & next are not null', () => { 
-    obj.total = "100";
-    obj.next = "7";
-    obj.operation = "-";
-    expect(calculate(obj, "=").total).toBe("93");
-    expect(calculate(obj, "=").next).toBe(null);
-    expect(calculate(obj, "=").operation).toBe(null);
-  }) 
-
-  test('test where button is = and operation or next are null', () => { 
-    obj.total = "100";
-    obj.next = "7";
-    obj.operation = null;
-    expect(calculate(obj, "=")).toStrictEqual({});
-  }) 
-
-  test('test where button is +/- and next is not null', () => { 
-    obj.total = "100";
-    obj.next = "7";
-    obj.operation = null;
-    expect(calculate(obj, "+/-").next).toBe("-7");
-  }) 
-
-  test('test where button is +/- and next is null', () => { 
-    obj.total = "100";
+  test('test where button is dot, total includes dot and operation & next are null', () => {
+    obj.total = '100';
     obj.next = null;
     obj.operation = null;
-    expect(calculate(obj, "+/-").total).toBe("-100");
-  }) 
+    expect(calculate(obj, '.').total).toBe('100.');
+  });
 
-  test('test where button is + and next & operation are null', () => { 
-    obj.total = "100";
+  test('test where button is = and operation & next are not null', () => {
+    obj.total = '100';
+    obj.next = '7';
+    obj.operation = '-';
+    expect(calculate(obj, '=').total).toBe('93');
+    expect(calculate(obj, '=').next).toBe(null);
+    expect(calculate(obj, '=').operation).toBe(null);
+  });
+
+  test('test where button is = and operation or next are null', () => {
+    obj.total = '100';
+    obj.next = '7';
+    obj.operation = null;
+    expect(calculate(obj, '=')).toStrictEqual({});
+  });
+
+  test('test where button is +/- and next is not null', () => {
+    obj.total = '100';
+    obj.next = '7';
+    obj.operation = null;
+    expect(calculate(obj, '+/-').next).toBe('-7');
+  });
+
+  test('test where button is +/- and next is null', () => {
+    obj.total = '100';
     obj.next = null;
-    obj.operation = "-";
-    expect(calculate(obj, "+").operation).toBe("+");
-    expect(calculate(obj, "+").total).toBe("100");
-  }) 
-  
-  test('test where button is + and next & operation are null', () => { 
-    obj.total = "100";
-    obj.next = "8";
-    obj.operation = "-";
-    expect(calculate(obj, "+").total).toBe("92");
-    expect(calculate(obj, "+").operation).toBe("+");
-    expect(calculate(obj, "+").next).toBe(null);
-  }) 
+    obj.operation = null;
+    expect(calculate(obj, '+/-').total).toBe('-100');
+  });
+
+  test('test where button is + and next & operation are null', () => {
+    obj.total = '100';
+    obj.next = null;
+    obj.operation = '-';
+    expect(calculate(obj, '+').operation).toBe('+');
+    expect(calculate(obj, '+').total).toBe('100');
+  });
+
+  test('test where button is + and next & operation are null', () => {
+    obj.total = '100';
+    obj.next = '8';
+    obj.operation = '-';
+    expect(calculate(obj, '+').total).toBe('92');
+    expect(calculate(obj, '+').operation).toBe('+');
+    expect(calculate(obj, '+').next).toBe(null);
+  });
 });

--- a/src/__tests__/operate.test.js
+++ b/src/__tests__/operate.test.js
@@ -1,35 +1,35 @@
 import operate from '../logic/operate';
 
-describe("test operate function", () => {
-  test('test 1 + 2 is 3', () => { 
-    expect(operate(1, 2, "+")).toBe("3");
-  })
+describe('test operate function', () => {
+  test('test 1 + 2 is 3', () => {
+    expect(operate(1, 2, '+')).toBe('3');
+  });
 
-  test('test 1 - 2 is -1', () => { 
-    expect(operate(1, 2, "-")).toBe("-1");
-  })
+  test('test 1 - 2 is -1', () => {
+    expect(operate(1, 2, '-')).toBe('-1');
+  });
 
-  test('test 1 x 2 is 2', () => { 
-    expect(operate(1, 2, "x")).toBe("2");
-  })
+  test('test 1 x 2 is 2', () => {
+    expect(operate(1, 2, 'x')).toBe('2');
+  });
 
-  test('test 4 ÷ 2 is 2', () => { 
-    expect(operate(4, 2, "÷")).toBe("2");
-  })
+  test('test 4 ÷ 2 is 2', () => {
+    expect(operate(4, 2, '÷')).toBe('2');
+  });
 
-  test('test 4 ÷ 0 throws an exceptions', () => { 
-    expect(operate(4, 0, "÷")).toBe("Can't divide by 0.");
-  })
-   
-  test('test 3 % 2 is 1', () => { 
-    expect(operate(1, 2, "%")).toBe("1");
-  })
+  test('test 4 ÷ 0 throws an exceptions', () => {
+    expect(operate(4, 0, '÷')).toBe("Can't divide by 0.");
+  });
 
-  test('test 4 % 0 throws an exceptions', () => { 
-    expect(operate(4, 0, "%")).toBe("Can't find modulo as can't divide by 0.");
-  })
+  test('test 3 % 2 is 1', () => {
+    expect(operate(1, 2, '%')).toBe('1');
+  });
 
-  test('Invalid operator throws an exceptions', () => { 
-    expect(() => operate(4, 0, "#")).toThrowError(/Unknown operation/);
-  })  
+  test('test 4 % 0 throws an exceptions', () => {
+    expect(operate(4, 0, '%')).toBe("Can't find modulo as can't divide by 0.");
+  });
+
+  test('Invalid operator throws an exceptions', () => {
+    expect(() => operate(4, 0, '#')).toThrowError(/Unknown operation/);
+  });
 });

--- a/src/__tests__/operate.test.js
+++ b/src/__tests__/operate.test.js
@@ -1,4 +1,4 @@
-import operate from './operate.js';
+import operate from '../logic/operate';
 
 describe("test operate function", () => {
   test('test 1 + 2 is 3', () => { 

--- a/src/components/Calculator.js
+++ b/src/components/Calculator.js
@@ -10,9 +10,11 @@ function Calculator() {
   const [operation, setOperation] = useState(null);
 
   const handleButtonClick = (name) => {
-    const { total: newTotal, next: newNext, operation: newOperation } = calculate(
-      { total, next, operation }, name,
-    );
+    const { 
+      total: newTotal, 
+      next: newNext, 
+      operation: newOperation 
+    } = calculate({ total, next, operation }, name,);
 
     setTotal(newTotal);
     setNext(newNext);

--- a/src/components/Calculator.js
+++ b/src/components/Calculator.js
@@ -10,11 +10,11 @@ function Calculator() {
   const [operation, setOperation] = useState(null);
 
   const handleButtonClick = (name) => {
-    const { 
-      total: newTotal, 
-      next: newNext, 
-      operation: newOperation 
-    } = calculate({ total, next, operation }, name,);
+    const {
+      total: newTotal,
+      next: newNext,
+      operation: newOperation,
+    } = calculate({ total, next, operation }, name);
 
     setTotal(newTotal);
     setNext(newNext);

--- a/src/components/Display.js
+++ b/src/components/Display.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 function Display(props) {
   const { text } = props;
   return (
-    <div className="display">{text || 0}</div>
+    <div role="display" className="display">{text || 0}</div>
   );
 }
 

--- a/src/components/Display.js
+++ b/src/components/Display.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 function Display(props) {
   const { text } = props;
   return (
-    <div role="display" className="display">{text || 0}</div>
+    <div data-testid="display" className="display">{text || 0}</div>
   );
 }
 

--- a/src/logic/operate.test.js
+++ b/src/logic/operate.test.js
@@ -1,0 +1,35 @@
+import operate from './operate.js';
+
+describe("test operate function", () => {
+  test('test 1 + 2 is 3', () => { 
+    expect(operate(1, 2, "+")).toBe("3");
+  })
+
+  test('test 1 - 2 is -1', () => { 
+    expect(operate(1, 2, "-")).toBe("-1");
+  })
+
+  test('test 1 x 2 is 2', () => { 
+    expect(operate(1, 2, "x")).toBe("2");
+  })
+
+  test('test 4 ÷ 2 is 2', () => { 
+    expect(operate(4, 2, "÷")).toBe("2");
+  })
+
+  test('test 4 ÷ 0 throws an exceptions', () => { 
+    expect(operate(4, 0, "÷")).toBe("Can't divide by 0.");
+  })
+   
+  test('test 3 % 2 is 1', () => { 
+    expect(operate(1, 2, "%")).toBe("1");
+  })
+
+  test('test 4 % 0 throws an exceptions', () => { 
+    expect(operate(4, 0, "%")).toBe("Can't find modulo as can't divide by 0.");
+  })
+
+  test('Invalid operator throws an exceptions', () => { 
+    expect(() => operate(4, 0, "#")).toThrowError(/Unknown operation/);
+  })  
+});


### PR DESCRIPTION
## What this PR does:
  - Added unit tests for the `operate.js` and `calculate.js` files using Jest
  - Created Snapshot tests for Button, Display and Calculator components using Jest snapshots.
  - Added unit test to simulate button click using React Testing Library

## How to test it
  - clone the repository by running\
      `https://github.com/gtekle/math-magicians.git`
  - navigate to the root folder\
      `cd math-magicians`
 - Install packages\
      `npm install`
  - run the app using\
      `npm start`
  - run tests using\
      `npm run test`

## Details